### PR TITLE
refactor: reduce verbose logging in spec and SDK generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,14 +137,14 @@ generate-ws-sdk:
 	@if [ "${EXCHANGE}" == "binance" ]; then \
 		if [ "${LANGUAGE}" == "go" ]; then \
 			for file in $(shell find specs/${EXCHANGE}/asyncapi -name "*.yaml" -depth 1); do \
-				echo "Generating ${EXCHANGE} go ws SDK for $$file"; \
 				subdir=$$(echo "$$file" | sed -n 's|.*asyncapi/\(.*\)\.yaml|\1|p'); \
+				echo "Generating ${EXCHANGE} ${LANGUAGE} WebSocket SDK for module: $$subdir"; \
 				rm -rf ${OUTPUT_DIR}/$$subdir; \
 				(cd templates/${EXCHANGE}/asyncapi/${LANGUAGE} && \
 				MODULE=$$subdir \
 				OUTPUT_DIR=${OUTPUT_DIR}/$$subdir \
 				ASYNCAPI_CLI=${ASYNCAPI_CLI:-asyncapi} \
-				npm run generate:module); \
+				npm run --silent generate:module 2>&1 | grep -v "ExperimentalWarning: CommonJS module" | grep -v "Support for loading ES Module in require()" | grep -v "Use \`node --trace-warnings"); \
 			done \
 		fi \
 	fi

--- a/internal/exchange/binance/websocket/umfutures_document_parser.go
+++ b/internal/exchange/binance/websocket/umfutures_document_parser.go
@@ -432,16 +432,16 @@ func (p *UmfuturesDocumentParser) extractContent(channel *parser.Channel, conten
 			logrus.Debugf("Processing JSON response for channel %s, JSON length: %d", channel.Name, len(jsonCode))
 
 			if responseSchema == nil {
-				logrus.Infof("Attempting to parse response JSON for channel %s", channel.Name)
+				logrus.Debugf("Attempting to parse response JSON for channel %s", channel.Name)
 				maxLen := 500
 				if len(jsonCode) < maxLen {
 					maxLen = len(jsonCode)
 				}
-				logrus.Infof("JSON to parse (first %d chars): %s", maxLen, jsonCode[:maxLen])
+				logrus.Debugf("JSON to parse (first %d chars): %s", maxLen, jsonCode[:maxLen])
 				responseSchema = p.SpotDocumentParser.DocumentParser.parseJSONSchema(jsonCode, "response")
 				// Check if the schema was parsed successfully by checking the description
 				if responseSchema != nil && responseSchema.Type != "" && len(responseSchema.Properties) > 0 {
-					logrus.Infof("Successfully parsed response schema for channel %s with %d properties", channel.Name, len(responseSchema.Properties))
+					logrus.Debugf("Successfully parsed response schema for channel %s with %d properties", channel.Name, len(responseSchema.Properties))
 				} else {
 					logrus.Errorf("Failed to parse response schema for channel %s", channel.Name)
 					logrus.Errorf("Failed JSON for %s: %s", channel.Name, jsonCode)

--- a/templates/binance/asyncapi/go/components/IndividualModels.js
+++ b/templates/binance/asyncapi/go/components/IndividualModels.js
@@ -127,7 +127,7 @@ export function IndividualModels({ asyncapi }) {
     // Skip if we already generated this type from channel messages
     const componentTypeName = toPascalCase(schemaName);
     if (generatedTypeNames.has(componentTypeName)) {
-      console.log(`Skipping duplicate component schema: ${schemaName} (already generated as ${componentTypeName})`);
+      // Skip duplicate - already generated as ${componentTypeName}
       return;
     }
     


### PR DESCRIPTION
- Move WebSocket response parsing logs from INFO to DEBUG level in umfutures parser
- Remove verbose "Skipping duplicate component schema" console.log in AsyncAPI template
- Filter npm-internal CommonJS/ES module warnings in SDK generation output
- Improve Makefile output formatting for WebSocket SDK generation

These changes significantly reduce log noise while maintaining important progress indicators and error messages.

🤖 Generated with [Claude Code](https://claude.ai/code)