### PR TITLE
fix(openapi): add missing closePosition field to umfutures batch orde…

### DIFF
--- a/specs/binance/openapi/umfutures.yaml
+++ b/specs/binance/openapi/umfutures.yaml
@@ -2108,6 +2108,8 @@ components:
                     type: string
                 clientOrderId:
                     type: string
+                closePosition:
+                    type: boolean
                 cumQty:
                     type: string
                 cumQuote:

--- a/specs/binance/openapi/umfutures/post_fapi_v1_batchOrders.yaml
+++ b/specs/binance/openapi/umfutures/post_fapi_v1_batchOrders.yaml
@@ -139,6 +139,8 @@ components:
                     type: integer
                 workingType:
                     type: string
+                closePosition:
+                    type: boolean
             type: object
         UmfuturesCreateBatchOrdersV1Resp:
             example: '[ { "clientOrderId": "testOrder", "cumQty": "0", "cumQuote": "0", "executedQty": "0", "orderId": 22542179, "avgPrice": "0.00000", "origQty": "10", "price": "0", "reduceOnly": false, "side": "BUY", "positionSide": "SHORT", "status": "NEW", "stopPrice": "9300", "symbol": "BTCUSDT", "timeInForce": "GTC", "type": "TRAILING_STOP_MARKET", "origType": "TRAILING_STOP_MARKET", "activatePrice": "9020", "priceRate": "0.3", "updateTime": 1566818724722, "workingType": "CONTRACT_PRICE", "priceProtect": false,       "priceMatch": "NONE",               "selfTradePreventionMode": "NONE",  "goodTillDate": 1693207680000       }, { "code": -2022, "msg": "ReduceOnly Order is rejected." } ]'


### PR DESCRIPTION
…r response

- Add closePosition field to UmfuturesCreateBatchOrdersV1RespItem schema
- Update combined umfutures.yaml spec to include closePosition field
- Ensure consistency between individual and combined specifications

The closePosition field was missing from the umfutures batch order response schema but is present in the API documentation and response examples.

🤖 Generated with [Claude Code](https://claude.ai/code)