### PR TITLE
fix(openapi): binance local entity withdraw response type spelling mistake

### DIFF
--- a/specs/binance/openapi/spot/post_sapi_v1_localentity_withdraw_apply.yaml
+++ b/specs/binance/openapi/spot/post_sapi_v1_localentity_withdraw_apply.yaml
@@ -53,9 +53,9 @@ components:
                 - questionnaire
             type: object
         CreateLocalentityWithdrawApplyV1Resp:
-            example: '{ "trId": 123456,  "accpted": true,  "info": "Withdraw request accepted"  }'
+            example: '{ "trId": 123456,  "accepted": true,  "info": "Withdraw request accepted"  }'
             properties:
-                accpted:
+                accepted:
                     type: boolean
                 info:
                     type: string


### PR DESCRIPTION
fix spelling mistake in binance local entity withdraw response type. accpted -> accepted.

Here is an example response I got from the api call:
```
{"accepted":false,"info":"Questionnaire must not be blank"}
```